### PR TITLE
feat: enhancements to the events feature

### DIFF
--- a/charts/kyverno-authz-server/templates/authz-server/deployment.yaml
+++ b/charts/kyverno-authz-server/templates/authz-server/deployment.yaml
@@ -120,6 +120,11 @@ spec:
           ports:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           args:
           - serve
           - '{{ $.Values.config.type }}'

--- a/charts/kyverno-authz-server/templates/rbac/cluster-role.yaml
+++ b/charts/kyverno-authz-server/templates/rbac/cluster-role.yaml
@@ -19,4 +19,28 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - openreports.io
+  resources:
+  - reports
+  - reports/status
+  - clusterreports
+  - clusterreports/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
 {{- end -}}

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect

--- a/pkg/commands/serve/envoy/authz-server/command.go
+++ b/pkg/commands/serve/envoy/authz-server/command.go
@@ -145,10 +145,17 @@ func Command() *cobra.Command {
 										logger.Info("error parsing the reports flush interval, will push results to the report immediately")
 									}
 									// todo: customize the report name based on pod name
+									reportName := "envoy-authz-report"
+									if podName := os.Getenv("POD_NAME"); podName != "" {
+										reportName = fmt.Sprintf("%s-%s", reportName, podName)
+									} else {
+										logger.Info("POD_NAME environment variable not set, using default report name. there may be a clash")
+									}
+
 									envoyEventHandlers = append(envoyEventHandlers, events.NewOpenreportsSubscriber[*authv3.CheckRequest](
 										ctx, resultBufSize,
 										orClient, intervalPtr, logger,
-										"envoy-authz-report", namespace, msgFormat))
+										reportName, namespace, msgFormat))
 								}
 							}
 						}

--- a/pkg/commands/serve/envoy/authz-server/command.go
+++ b/pkg/commands/serve/envoy/authz-server/command.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	authv3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -148,7 +149,8 @@ func Command() *cobra.Command {
 									}
 									reportName := "envoy-authz-report"
 									if podName := os.Getenv("POD_NAME"); podName != "" {
-										reportName = fmt.Sprintf("%s-%s", reportName, podName)
+										podNameHash := xxhash.Sum64String(podName)
+										reportName = fmt.Sprintf("%s-%x", reportName, podNameHash)
 									} else {
 										logger.Info("POD_NAME environment variable not set, using default report name. there may be a clash")
 									}

--- a/pkg/commands/serve/envoy/authz-server/command.go
+++ b/pkg/commands/serve/envoy/authz-server/command.go
@@ -21,21 +21,18 @@ import (
 	"github.com/kyverno/kyverno-authz/pkg/events"
 	"github.com/kyverno/kyverno-authz/pkg/probes"
 	"github.com/kyverno/kyverno-authz/pkg/signals"
+	"github.com/kyverno/kyverno-authz/pkg/utils"
 	"github.com/kyverno/kyverno-authz/pkg/utils/ocifs"
 	"github.com/kyverno/sdk/core"
 	sdksources "github.com/kyverno/sdk/core/sources"
 	openreportsclient "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	"github.com/spf13/cobra"
 	"go.uber.org/multierr"
-	apixv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -133,7 +130,7 @@ func Command() *cobra.Command {
 
 						// add the openreports event handler
 						if openreportsEnabled {
-							if exists, err := crdExists(config, "reports.openreports.io"); err == nil && exists {
+							if exists, err := utils.CrdExists(config, "reports.openreports.io"); err == nil && exists {
 								orClient, err := openreportsclient.NewForConfig(config)
 								if err != nil {
 									logger.Error(err, "failed to instantiate openreports client")
@@ -251,7 +248,7 @@ func Command() *cobra.Command {
 	command.Flags().BoolVar(&eventsEnabled, "events-enabled", false, "Enable k8s events on authz, if not running in k8s this flag won't take effect")
 	command.Flags().BoolVar(&openreportsEnabled, "openreports-enabled", false, "Enable reporting in the openreports format, if not running in k8s or the openreports CRD is not installed this flag won't take effect")
 	command.Flags().StringVar(&reportFlushInterval, "report-flush-interval", "", "how often do results get flushed into the openreports report (if active)")
-	command.Flags().StringVar(&msgFormat, "log-msg-format", "[%s] http: request %s, response: %s\n", "The format in which request logs would be shown in stdout")
+	command.Flags().StringVar(&msgFormat, "log-msg-format", "[%s] envoy: request %s, response: %s\n", "The format in which request logs would be shown in stdout")
 	command.Flags().IntVar(&resultBufSize, "result-buffer-size", 500, "Event buffer size for openreports, note that if the total exceeded the 1MB etcd limit, report flushing will error")
 	clientcmd.BindOverrideFlags(&kubeConfigOverrides, command.Flags(), clientcmd.RecommendedConfigOverrideFlags("kube-"))
 	return command
@@ -280,25 +277,4 @@ func getExternalSources[POLICY any](vpolCompiler engine.Compiler[POLICY], nOpts 
 		)
 	}
 	return providers, nil
-}
-
-// ammar: move this to a generic utils file
-func crdExists(cfg *rest.Config, crdName string) (bool, error) {
-	client, err := apixv1.NewForConfig(cfg)
-	if err != nil {
-		return false, err
-	}
-
-	_, err = client.ApiextensionsV1().
-		CustomResourceDefinitions().
-		Get(context.Background(), crdName, metav1.GetOptions{})
-
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
 }

--- a/pkg/commands/serve/envoy/authz-server/command.go
+++ b/pkg/commands/serve/envoy/authz-server/command.go
@@ -124,7 +124,7 @@ func Command() *cobra.Command {
 						if eventsEnabled {
 							envoyEventHandlers = append(envoyEventHandlers,
 								events.NewK8sEventSubscriber[*authv3.CheckRequest](
-									kubeclient, namespace,
+									ctx, kubeclient, namespace,
 									logger, msgFormat))
 						}
 
@@ -146,7 +146,7 @@ func Command() *cobra.Command {
 									}
 									// todo: customize the report name based on pod name
 									envoyEventHandlers = append(envoyEventHandlers, events.NewOpenreportsSubscriber[*authv3.CheckRequest](
-										resultBufSize,
+										ctx, resultBufSize,
 										orClient, intervalPtr, logger,
 										"envoy-authz-report", namespace, msgFormat))
 								}

--- a/pkg/commands/serve/envoy/authz-server/command.go
+++ b/pkg/commands/serve/envoy/authz-server/command.go
@@ -144,7 +144,6 @@ func Command() *cobra.Command {
 									} else {
 										logger.Info("error parsing the reports flush interval, will push results to the report immediately")
 									}
-									// todo: customize the report name based on pod name
 									reportName := "envoy-authz-report"
 									if podName := os.Getenv("POD_NAME"); podName != "" {
 										reportName = fmt.Sprintf("%s-%s", reportName, podName)

--- a/pkg/commands/serve/envoy/authz-server/command.go
+++ b/pkg/commands/serve/envoy/authz-server/command.go
@@ -130,7 +130,9 @@ func Command() *cobra.Command {
 
 						// add the openreports event handler
 						if openreportsEnabled {
-							if exists, err := utils.CrdExists(config, "reports.openreports.io"); err == nil && exists {
+							if exists, err := utils.CrdExists(config, "reports.openreports.io"); err != nil {
+								logger.Error(err, "failed to check if openreports CRD exists")
+							} else if exists {
 								orClient, err := openreportsclient.NewForConfig(config)
 								if err != nil {
 									logger.Error(err, "failed to instantiate openreports client")

--- a/pkg/commands/serve/http/authz-server/command.go
+++ b/pkg/commands/serve/http/authz-server/command.go
@@ -21,21 +21,18 @@ import (
 	"github.com/kyverno/kyverno-authz/pkg/events"
 	"github.com/kyverno/kyverno-authz/pkg/probes"
 	"github.com/kyverno/kyverno-authz/pkg/signals"
+	"github.com/kyverno/kyverno-authz/pkg/utils"
 	"github.com/kyverno/kyverno-authz/pkg/utils/ocifs"
 	"github.com/kyverno/sdk/core"
 	sdksources "github.com/kyverno/sdk/core/sources"
 	openreportsclient "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	"github.com/spf13/cobra"
 	"go.uber.org/multierr"
-	apixv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -140,7 +137,7 @@ func Command() *cobra.Command {
 						}
 
 						if openreportsEnabled {
-							if exists, err := crdExists(config, "reports.openreports.io"); err == nil && exists {
+							if exists, err := utils.CrdExists(config, "reports.openreports.io"); err == nil && exists {
 								orClient, err := openreportsclient.NewForConfig(config)
 								if err != nil {
 									logger.Error(err, "failed to instantiate openreports client")
@@ -298,25 +295,4 @@ func getExternalSources[POLICY any](vpolCompiler engine.Compiler[POLICY], nOpts 
 		)
 	}
 	return providers, nil
-}
-
-// ammar: move this to a generic utils file
-func crdExists(cfg *rest.Config, crdName string) (bool, error) {
-	client, err := apixv1.NewForConfig(cfg)
-	if err != nil {
-		return false, err
-	}
-
-	_, err = client.ApiextensionsV1().
-		CustomResourceDefinitions().
-		Get(context.Background(), crdName, metav1.GetOptions{})
-
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
 }

--- a/pkg/commands/serve/http/authz-server/command.go
+++ b/pkg/commands/serve/http/authz-server/command.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/hairyhenderson/go-fsimpl"
@@ -156,7 +157,8 @@ func Command() *cobra.Command {
 									}
 									reportName := "http-authz-report"
 									if podName := os.Getenv("POD_NAME"); podName != "" {
-										reportName = fmt.Sprintf("%s-%s", reportName, podName)
+										podNameHash := xxhash.Sum64String(podName)
+										reportName = fmt.Sprintf("%s-%x", reportName, podNameHash)
 									} else {
 										logger.Info("POD_NAME environment variable not set, using default report name. there may be a clash")
 									}

--- a/pkg/commands/serve/http/authz-server/command.go
+++ b/pkg/commands/serve/http/authz-server/command.go
@@ -129,6 +129,7 @@ func Command() *cobra.Command {
 
 						if eventsEnabled {
 							httpEventHandlers = append(httpEventHandlers, events.NewK8sEventSubscriber[httplib.CheckRequest](
+								ctx,
 								kubeclient,
 								namespace,
 								logger,
@@ -153,7 +154,7 @@ func Command() *cobra.Command {
 									}
 
 									httpEventHandlers = append(httpEventHandlers, events.NewOpenreportsSubscriber[httplib.CheckRequest](
-										resultBufSize,
+										ctx, resultBufSize,
 										orClient, intervalPtr, logger,
 										"http-authz-report", namespace, msgFormat))
 								}
@@ -210,7 +211,6 @@ func Command() *cobra.Command {
 						}
 					} else {
 						compiler := vpolcompiler.NewCompiler[dynamic.Interface, *httplib.CheckRequest, *httplib.CheckResponse](nil)
-
 						rOpts, nOpts, err := ocifs.RegistryOpts(nil, allowInsecureRegistry)
 						if err != nil {
 							return fmt.Errorf("failed to initialize registry opts: %w", err)

--- a/pkg/commands/serve/http/authz-server/command.go
+++ b/pkg/commands/serve/http/authz-server/command.go
@@ -138,7 +138,9 @@ func Command() *cobra.Command {
 						}
 
 						if openreportsEnabled {
-							if exists, err := utils.CrdExists(config, "reports.openreports.io"); err == nil && exists {
+							if exists, err := utils.CrdExists(config, "reports.openreports.io"); err != nil {
+								logger.Error(err, "failed to check if openreports CRD exists")
+							} else if exists {
 								orClient, err := openreportsclient.NewForConfig(config)
 								if err != nil {
 									logger.Error(err, "failed to instantiate openreports client")

--- a/pkg/commands/serve/http/authz-server/command.go
+++ b/pkg/commands/serve/http/authz-server/command.go
@@ -152,11 +152,17 @@ func Command() *cobra.Command {
 									} else {
 										logger.Info("error parsing the reports flush interval, will push results to the report immediately")
 									}
+									reportName := "http-authz-report"
+									if podName := os.Getenv("POD_NAME"); podName != "" {
+										reportName = fmt.Sprintf("%s-%s", reportName, podName)
+									} else {
+										logger.Info("POD_NAME environment variable not set, using default report name. there may be a clash")
+									}
 
 									httpEventHandlers = append(httpEventHandlers, events.NewOpenreportsSubscriber[httplib.CheckRequest](
 										ctx, resultBufSize,
 										orClient, intervalPtr, logger,
-										"http-authz-report", namespace, msgFormat))
+										reportName, namespace, msgFormat))
 								}
 							}
 						}

--- a/pkg/events/iface.go
+++ b/pkg/events/iface.go
@@ -62,6 +62,12 @@ func (r *resultAccessorImpl) MustGet() (string, error) {
 	}
 }
 
+type event[Req any] struct {
+	t   time.Time
+	req Req
+	res ResultAccessor
+}
+
 func NewComposite[Req any](subsribers ...EventIface[Req]) EventIface[Req] {
 	return &CompositeEventSubscriber[Req]{
 		inner: subsribers,
@@ -70,7 +76,6 @@ func NewComposite[Req any](subsribers ...EventIface[Req]) EventIface[Req] {
 
 func (c *CompositeEventSubscriber[Req]) Push(ctx context.Context, t time.Time, req Req, res ResultAccessor) {
 	for _, sub := range c.inner {
-		// TODO: sync wait group and error returns if we want the process to be synchronous
-		go sub.Push(ctx, t, req, res)
+		sub.Push(ctx, t, req, res)
 	}
 }

--- a/pkg/events/k8sevents.go
+++ b/pkg/events/k8sevents.go
@@ -27,7 +27,7 @@ type k8sEventSubscriber[Req any] struct {
 
 // pass a context to the constructor to make it the context used to cancel the event loop
 func NewK8sEventSubscriber[Req any](ctx context.Context, client kubernetes.Interface, ns string, logger logr.Logger, msgFormat string) EventIface[Req] {
-	eventChan := make(chan event[Req], 10)
+	eventChan := make(chan event[Req], 50)
 	k := &k8sEventSubscriber[Req]{
 		client:    client,
 		namespace: ns,

--- a/pkg/events/k8sevents.go
+++ b/pkg/events/k8sevents.go
@@ -22,64 +22,93 @@ type k8sEventSubscriber[Req any] struct {
 	namespace string
 	logger    logr.Logger
 	msgFormat string
+	eventChan chan event[Req]
 }
 
-func NewK8sEventSubscriber[Req any](client kubernetes.Interface, ns string, logger logr.Logger, msgFormat string) EventIface[Req] {
-	return &k8sEventSubscriber[Req]{
+// pass a context to the constructor to make it the context used to cancel the event loop
+func NewK8sEventSubscriber[Req any](ctx context.Context, client kubernetes.Interface, ns string, logger logr.Logger, msgFormat string) EventIface[Req] {
+	eventChan := make(chan event[Req], 10)
+	k := &k8sEventSubscriber[Req]{
 		client:    client,
 		namespace: ns,
 		logger:    logger,
 		msgFormat: msgFormat,
+		eventChan: eventChan,
+	}
+	go k.eventLoop(ctx)
+	return k
+}
+
+func (k *k8sEventSubscriber[Req]) eventLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			k.logger.Info("k8s event handler exiting")
+			return
+		case ev := <-k.eventChan:
+			jsonReq, err := json.Marshal(ev.req)
+			if err != nil {
+				k.logger.Error(err, "error marshalling request to json for event")
+				continue
+			}
+
+			result, resultErr := ev.res.MustGet()
+
+			var resultStr string
+			if resultErr != nil {
+				resultStr = fmt.Sprintf("%v: %v", result, resultErr)
+			} else {
+				resultStr = fmt.Sprintf("%v", result)
+			}
+
+			eventMsg := fmt.Sprintf(k.msgFormat,
+				ev.t.Format(time.RFC3339),
+				string(jsonReq),
+				resultStr,
+			)
+
+			eventName := strings.ReplaceAll(uuid.New().String(), "-", "")
+			event := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      eventName,
+					Namespace: k.namespace,
+				},
+				Reason:              result,
+				Message:             eventMsg,
+				Type:                corev1.EventTypeNormal,
+				EventTime:           metav1.NewMicroTime(ev.t),
+				FirstTimestamp:      metav1.NewTime(ev.t),
+				LastTimestamp:       metav1.NewTime(ev.t),
+				Count:               1,
+				Action:              result,
+				ReportingController: "kyverno-authz-server",
+				ReportingInstance:   "kyverno-authz-server",
+			}
+
+			_, err = k.client.CoreV1().Events(k.namespace).Create(
+				ctx,
+				event,
+				metav1.CreateOptions{},
+			)
+
+			if err != nil {
+				k.logger.Error(err, "failed to push kubernetes event")
+			}
+		}
 	}
 }
 
 func (k *k8sEventSubscriber[Req]) Push(ctx context.Context, t time.Time, req Req, res ResultAccessor) {
-	jsonReq, err := json.Marshal(req)
-	if err != nil {
-		k.logger.Error(err, "error marshalling request to json for event")
-		return
+	event := event[Req]{
+		t:   t,
+		req: req,
+		res: res,
 	}
 
-	result, resultErr := res.MustGet()
-
-	var resultStr string
-	if resultErr != nil {
-		resultStr = fmt.Sprintf("%v: %v", result, resultErr)
-	} else {
-		resultStr = fmt.Sprintf("%v", result)
-	}
-
-	eventMsg := fmt.Sprintf(k.msgFormat,
-		t.Format(time.RFC3339),
-		string(jsonReq),
-		resultStr,
-	)
-
-	eventName := strings.ReplaceAll(uuid.New().String(), "-", "")
-	event := &corev1.Event{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      eventName,
-			Namespace: k.namespace,
-		},
-		Reason:              result,
-		Message:             eventMsg,
-		Type:                corev1.EventTypeNormal,
-		EventTime:           metav1.NewMicroTime(t),
-		FirstTimestamp:      metav1.NewTime(t),
-		LastTimestamp:       metav1.NewTime(t),
-		Count:               1,
-		Action:              result,
-		ReportingController: "kyverno-authz-server",
-		ReportingInstance:   "kyverno-authz-server",
-	}
-
-	_, err = k.client.CoreV1().Events(k.namespace).Create(
-		ctx,
-		event,
-		metav1.CreateOptions{},
-	)
-
-	if err != nil {
-		k.logger.Error(err, "failed to push kubernetes event")
+	// try to push the event, drop it if the channel is full
+	select {
+	case k.eventChan <- event:
+	default:
+		k.logger.Error(nil, "event channel full, dropping event")
 	}
 }

--- a/pkg/events/k8sevents.go
+++ b/pkg/events/k8sevents.go
@@ -109,6 +109,6 @@ func (k *k8sEventSubscriber[Req]) Push(ctx context.Context, t time.Time, req Req
 	select {
 	case k.eventChan <- event:
 	default:
-		k.logger.Error(nil, "event channel full, dropping event")
+		k.logger.Error(nil, "k8s events event handler: event channel full, dropping event")
 	}
 }

--- a/pkg/events/openreports.go
+++ b/pkg/events/openreports.go
@@ -174,9 +174,9 @@ func (o *openreportsEventSubscriber[Req]) pushReport(ctx context.Context) {
 	rep.Results = o.results.Values()
 
 	// update the report summary
-	rep.Summary.Error = int(o.allowed.Load())
+	rep.Summary.Error = int(o.errored.Load())
 	rep.Summary.Pass = int(o.allowed.Load())
-	rep.Summary.Fail = int(o.allowed.Load())
+	rep.Summary.Fail = int(o.denied.Load())
 
 	_, err = o.client.Reports(o.namespace).Update(ctx, rep, metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/events/openreports.go
+++ b/pkg/events/openreports.go
@@ -66,7 +66,7 @@ func (o *openreportsEventSubscriber[Req]) eventLoop(ctx context.Context) {
 			reportResult, err := o.newReportResult(ev.t, ev.req, ev.res)
 			if err != nil {
 				o.logger.Error(err, "error building report result")
-				return
+				continue
 			}
 
 			o.results.Push(*reportResult)

--- a/pkg/events/openreports.go
+++ b/pkg/events/openreports.go
@@ -91,7 +91,7 @@ func (o *openreportsEventSubscriber[Req]) Push(ctx context.Context, t time.Time,
 	select {
 	case o.eventChan <- event:
 	default:
-		o.logger.Error(nil, "event channel full, dropping event")
+		o.logger.Error(nil, "openreports event handler: event channel full, dropping event")
 	}
 }
 

--- a/pkg/events/openreports.go
+++ b/pkg/events/openreports.go
@@ -25,45 +25,74 @@ type openreportsEventSubscriber[Req any] struct {
 	msgFormat     string
 	logger        logr.Logger
 	flushInterval *time.Duration
+	eventChan     chan event[Req]
 }
 
-func NewOpenreportsSubscriber[Req any](bufferSize int,
+// pass a context to the constructor to make it the context used to cancel the event loop
+func NewOpenreportsSubscriber[Req any](ctx context.Context, bufferSize int,
 	orClient openreportsclient.OpenreportsV1alpha1Interface,
 	flushInterval *time.Duration,
 	logger logr.Logger,
 	reportName, ns, msgFormat string) EventIface[Req] {
 	o := &openreportsEventSubscriber[Req]{
-		client:     orClient,
+		client: orClient,
+		// we don't need the ring buffer to contain a mutex because in all cases we process events serially
 		results:    NewRingBuffer[openreportsv1alpha1.ReportResult](bufferSize),
 		namespace:  ns,
 		reportName: reportName,
 		msgFormat:  msgFormat,
 		logger:     logger,
+		eventChan:  make(chan event[Req], 10), // we can buffer up to 10 events
 	}
+
 	if flushInterval != nil {
 		o.flushInterval = flushInterval
-		go o.flushResultsToReport(context.Background())
+		go o.flushResultsToReport(ctx)
 	}
+
+	// if there is a flush interval we still want to run the event loop to append results to the report as they come.
+	// but we will patch/create the live report on interval elapsing
+	go o.eventLoop(ctx)
 	return o
+}
+
+func (o *openreportsEventSubscriber[Req]) eventLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			o.logger.Info("openreports event handler exiting")
+			return
+		case ev := <-o.eventChan:
+			reportResult, err := o.newReportResult(ev.t, ev.req, ev.res)
+			if err != nil {
+				o.logger.Error(err, "error building report result")
+				return
+			}
+
+			o.results.Push(*reportResult)
+			// no need to do anything further if we are gonna be pushing on an interval
+			if o.flushInterval != nil {
+				continue
+			}
+
+			o.pushReport(ctx)
+		}
+	}
 }
 
 // ammar: should we also convey the policy that caused the decision ?
 func (o *openreportsEventSubscriber[Req]) Push(ctx context.Context, t time.Time, req Req, res ResultAccessor) {
-	reportResult, err := o.newReportResult(t, req, res)
-	if err != nil {
-		o.logger.Error(err, "error building report result")
-		return
+	event := event[Req]{
+		t:   t,
+		req: req,
+		res: res,
 	}
-
-	o.results.Push(*reportResult)
-
-	// the new report result already did the aggregation and we will handle pushing the report
-	// when the interval is elapsed
-	if o.flushInterval != nil {
-		return
+	// try to push the event, drop it if the channel is full
+	select {
+	case o.eventChan <- event:
+	default:
+		o.logger.Error(nil, "event channel full, dropping event")
 	}
-
-	o.pushReport(ctx)
 }
 
 func (o *openreportsEventSubscriber[Req]) newReportResult(t time.Time, r Req, resultAccessor ResultAccessor) (*openreportsv1alpha1.ReportResult, error) {
@@ -71,7 +100,6 @@ func (o *openreportsEventSubscriber[Req]) newReportResult(t time.Time, r Req, re
 	// ammar: is there a constant provided in the openreports package ?
 	// ammar: we should also have request skipped if it didn't match the conditions
 	res, resultErr := resultAccessor.MustGet()
-
 	switch res {
 	case RequestAllowed:
 		reportResult.Result = openreportsv1alpha1.Result("pass")
@@ -157,11 +185,11 @@ func (o *openreportsEventSubscriber[Req]) pushReport(ctx context.Context) {
 	}
 }
 
-// TODO: handle context cancellation
 func (o *openreportsEventSubscriber[Req]) flushResultsToReport(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			o.logger.Info("report interval flush worker exiting")
 			return
 		case <-time.After(*o.flushInterval):
 			o.pushReport(ctx)

--- a/pkg/events/openreports.go
+++ b/pkg/events/openreports.go
@@ -42,7 +42,7 @@ func NewOpenreportsSubscriber[Req any](ctx context.Context, bufferSize int,
 		reportName: reportName,
 		msgFormat:  msgFormat,
 		logger:     logger,
-		eventChan:  make(chan event[Req], 10), // we can buffer up to 10 events
+		eventChan:  make(chan event[Req], 50), // we can buffer up to 50 events
 	}
 
 	if flushInterval != nil {

--- a/pkg/events/ringbuf.go
+++ b/pkg/events/ringbuf.go
@@ -1,6 +1,8 @@
 package events
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type ringBuffer[T any] struct {
 	data  []T

--- a/pkg/events/writer.go
+++ b/pkg/events/writer.go
@@ -26,7 +26,7 @@ func NewWriterEventSubscriber[Req any](w io.Writer, l logr.Logger, msgFormat str
 }
 
 func (s *writerEventSubscriber[Req]) Push(_ context.Context, t time.Time, req Req, res ResultAccessor) {
-	// its ok for the standard output writer to be synchronous
+	// it's ok for the standard output writer to be synchronous
 	jsonStr, err := json.Marshal(req)
 	if err != nil {
 		s.logger.Error(err, "error unmarshalling request")

--- a/pkg/events/writer.go
+++ b/pkg/events/writer.go
@@ -26,6 +26,7 @@ func NewWriterEventSubscriber[Req any](w io.Writer, l logr.Logger, msgFormat str
 }
 
 func (s *writerEventSubscriber[Req]) Push(_ context.Context, t time.Time, req Req, res ResultAccessor) {
+	// its ok for the standard output writer to be synchronous
 	jsonStr, err := json.Marshal(req)
 	if err != nil {
 		s.logger.Error(err, "error unmarshalling request")

--- a/pkg/utils/crd.go
+++ b/pkg/utils/crd.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+
+	apixv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CrdExists(cfg *rest.Config, crdName string) (bool, error) {
+	client, err := apixv1.NewForConfig(cfg)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = client.ApiextensionsV1().
+		CustomResourceDefinitions().
+		Get(context.Background(), crdName, metav1.GetOptions{})
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/utils/crd.go
+++ b/pkg/utils/crd.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
@@ -16,9 +17,12 @@ func CrdExists(cfg *rest.Config, crdName string) (bool, error) {
 		return false, err
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	_, err = client.ApiextensionsV1().
 		CustomResourceDefinitions().
-		Get(context.Background(), crdName, metav1.GetOptions{})
+		Get(ctx, crdName, metav1.GetOptions{})
 
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/website/docs/reference/commands/kyverno-authz_serve_envoy_authz-server.md
+++ b/website/docs/reference/commands/kyverno-authz_serve_envoy_authz-server.md
@@ -42,7 +42,7 @@ kyverno-authz serve envoy authz-server [flags]
       --kube-token string                    Bearer token for authentication to the API server
       --kube-user string                     The name of the kubeconfig user to use
       --kube-username string                 Username for basic authentication to the API server
-      --log-msg-format string                The format in which request logs would be shown in stdout (default "[%s] http: request %s, response: %s\n")
+      --log-msg-format string                The format in which request logs would be shown in stdout (default "[%s] envoy: request %s, response: %s\n")
       --metrics-address string               Address to listen on for metrics (default ":9082")
       --openreports-enabled                  Enable reporting in the openreports format, if not running in k8s or the openreports CRD is not installed this flag won't take effect
       --probes-address string                Address to listen on for health checks

--- a/website/docs/server/envoy/authz-server.md
+++ b/website/docs/server/envoy/authz-server.md
@@ -35,7 +35,7 @@ kyverno-authz serve envoy authz-server [flags]
       --kube-token string                    Bearer token for authentication to the API server
       --kube-user string                     The name of the kubeconfig user to use
       --kube-username string                 Username for basic authentication to the API server
-      --log-msg-format string                The format in which request logs would be shown in stdout (default "[%s] http: request %s, response: %s\n")
+      --log-msg-format string                The format in which request logs would be shown in stdout (default "[%s] envoy: request %s, response: %s\n")
       --metrics-address string               Address to listen on for metrics (default ":9082")
       --openreports-enabled                  Enable reporting in the openreports format, if not running in k8s or the openreports CRD is not installed this flag won't take effect
       --probes-address string                Address to listen on for health checks


### PR DESCRIPTION
## Explanation

- add event buffering to the openreports and k8sevents event handler. when they receive an event they will push it to an internal buffered channel and try to consume it through an event loop
- if the buffered channel is full, the event is dropped to avoid blocking processing the authz request
- move `crdExists` to a common utils file
- customize report name based on pod name and pass the pod name through the downward api and hash it to avoid exceeded kubernetes resource name limit
- fix typo in envoy msg format which said http instead of envoy